### PR TITLE
wallet: Fix wrong wait group count

### DIFF
--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -141,7 +141,7 @@ func (w *Wallet) Start() {
 	}
 	w.quitMu.Unlock()
 
-	w.wg.Add(2)
+	w.wg.Add(3)
 	go w.txCreator()
 	go w.txTransferCreator()
 	go w.walletLocker()


### PR DESCRIPTION
Increased waitgroup count to 3. Fixes #2 