### PR TITLE
Develop

### DIFF
--- a/wallet/coincasetx.go
+++ b/wallet/coincasetx.go
@@ -19,7 +19,7 @@ func createCoincaseScript() ([]byte, error) {
 }
 
 // Reference : btcsuite\btcd\mining\mining.go:253
-func newCoincaseTransaction(pkScript []byte, amount int64, lockTime uint32) (
+func newCoincaseTransaction(pkScript []byte, amount int64) (
 	*btcutil.Tx, error) {
 	var err error
 
@@ -43,17 +43,13 @@ func newCoincaseTransaction(pkScript []byte, amount int64, lockTime uint32) (
 		PkScript: pkScript,
 	})
 
-	tx.LockTime = lockTime
-
 	// Reference : btcsuite\btcd\mining\mining.go:805
 	// TODO : Check segwit related codes
 
 	return btcutil.NewTx(tx), nil
 }
 
-func (w *Wallet) createCoincase(
-	coincaseAddr btcutil.Address,
-	amount int64, lockTime uint32) (coincaseTx *btcutil.Tx, err error) {
+func (w *Wallet) createCoincase(coincaseAddr btcutil.Address, amount int64) (coincaseTx *btcutil.Tx, err error) {
 
 	// Create coincase
 	pkScript, err := txscript.PayToAddrScript(coincaseAddr)
@@ -61,6 +57,6 @@ func (w *Wallet) createCoincase(
 		return
 	}
 
-	coincaseTx, err = newCoincaseTransaction(pkScript, amount, lockTime)
+	coincaseTx, err = newCoincaseTransaction(pkScript, amount)
 	return
 }


### PR DESCRIPTION
coincasetx: Remove locktime from coincase tx 
Post dating feature is related to transaction created from coincase.
Coincase tx has nothing to do with locktime.


postdated: Change to 'txauthor.AuthoredTx' to 'AuthoredPostDatedTx' to include coincase tx

Coincase tx needed to be sent to btcd for processing, because it doesn't
exist in mempool and sending only the hash of it is not enough.
Implementation is not finished yet.

Fixes:
Change totalInput to correct value. TotalInput value of 'txauthor.AuthoredTx'
need to total amount of all inputs (not count of inputs).
Set locktime to created tx explicitly (don't set the coincase tx)