### PR TITLE
Remove sending custom post dated tx message to btcd.

### DIFF
--- a/chain/bitcoind_client.go
+++ b/chain/bitcoind_client.go
@@ -195,13 +195,6 @@ func (c *BitcoindClient) SendRawTransaction(tx *wire.MsgTx,
 	return c.chainConn.client.SendRawTransaction(tx, allowHighFees)
 }
 
-// SendRawTransaction sends a raw transaction via bitcoind.
-func (c *BitcoindClient) SendRawPostDatedTransaction(tx *wire.MsgPostDatedTx,
-	allowHighFees bool) (*chainhash.Hash, error) {
-
-	return c.chainConn.client.SendRawPostDatedTransaction(tx, allowHighFees)
-}
-
 // Notifications returns a channel to retrieve notifications from.
 //
 // NOTE: This is part of the chain.Interface interface.

--- a/chain/interface.go
+++ b/chain/interface.go
@@ -34,7 +34,6 @@ type Interface interface {
 	FilterBlocks(*FilterBlocksRequest) (*FilterBlocksResponse, error)
 	BlockStamp() (*waddrmgr.BlockStamp, error)
 	SendRawTransaction(*wire.MsgTx, bool) (*chainhash.Hash, error)
-	SendRawPostDatedTransaction(*wire.MsgPostDatedTx, bool) (*chainhash.Hash, error)
 	Rescan(*chainhash.Hash, []btcutil.Address, map[wire.OutPoint]btcutil.Address) error
 	NotifyReceived([]btcutil.Address) error
 	NotifyBlocks() error

--- a/chain/neutrino.go
+++ b/chain/neutrino.go
@@ -167,13 +167,6 @@ func (s *NeutrinoClient) SendRawTransaction(tx *wire.MsgTx, allowHighFees bool) 
 	return &hash, nil
 }
 
-// SendRawTransaction replicates the RPC client's SendRawTransaction command.
-func (s *NeutrinoClient) SendRawPostDatedTransaction(tx *wire.MsgPostDatedTx, allowHighFees bool) (
-	*chainhash.Hash, error) {
-	// TODO : Implement this
-	return nil, nil
-}
-
 // FilterBlocks scans the blocks contained in the FilterBlocksRequest for any
 // addresses of interest. For each requested block, the corresponding compact
 // filter will first be checked for matches, skipping those that do not report

--- a/rpc/legacyrpc/methods.go
+++ b/rpc/legacyrpc/methods.go
@@ -1516,9 +1516,11 @@ func sendPostDatedTx(icmd interface{}, w *wallet.Wallet) (interface{}, error) {
 		}
 	}
 
-	txHashStr := redeemTxHash.String()
-	log.Infof("Successfully transferred transaction %v", txHashStr)
-	return txHashStr, nil
+	coincaseTxHashStr := redeemTxHash[0].String()
+	postDatedTxHashStr := redeemTxHash[0].String()
+	log.Infof("Successfully transferred post-dated transaction %v (coincase : %v)",
+		postDatedTxHashStr, coincaseTxHashStr)
+	return []string{coincaseTxHashStr, postDatedTxHashStr}, nil
 }
 
 // TODO : write summary

--- a/wallet/coincasetx.go
+++ b/wallet/coincasetx.go
@@ -7,28 +7,17 @@ import (
 	"github.com/btcsuite/btcutil"
 )
 
-const (
-	coincaseTxFlags = "/POSTDATED/"
-
-	// TODO : Need to be in wire package
-	PostDatedTxVersion = 2
-)
-
-func createCoincaseScript() ([]byte, error) {
-	return txscript.NewScriptBuilder().AddData([]byte(coincaseTxFlags)).Script()
-}
-
 // Reference : btcsuite\btcd\mining\mining.go:253
 func newCoincaseTransaction(pkScript []byte, amount int64) (
 	*btcutil.Tx, error) {
 	var err error
 
-	postDatedScript, err := createCoincaseScript()
+	postDatedScript, err := txscript.CreateCoincaseScript()
 	if err != nil {
 		return nil, err
 	}
 
-	tx := wire.NewMsgTx(PostDatedTxVersion)
+	tx := wire.NewMsgTx(wire.PostDatedTxVersion)
 
 	tx.AddTxIn(&wire.TxIn{
 		// Coincase transactions have no inputs, so previous outpoint is


### PR DESCRIPTION
Instead send coincase and post dated transactions as a regular tx message

wallet/coincase: Move post-dated tx related const to btcd
wallet/postdated: send coincase and postdated tx separately